### PR TITLE
docs: Fix typo s/chat/chart/

### DIFF
--- a/security-api/index.html
+++ b/security-api/index.html
@@ -38,7 +38,7 @@
     <script src="./JS/fetch-api.js"></script>
     <script src="./JS/radar-chart.js"></script> 
     <script src="./JS/faq.js"></script> 
-    <!--to generate the chat, we use an external library. Documentation is available at: https://www.chartjs.org/docs/latest/getting-started/-->
+    <!--to generate the chart, we use an external library. Documentation is available at: https://www.chartjs.org/docs/latest/getting-started/-->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Spotted another little typo when poking around in the web source.